### PR TITLE
#9:  GetUsage now throws ArgException

### DIFF
--- a/ArgsTests/BasicTests.cs
+++ b/ArgsTests/BasicTests.cs
@@ -332,5 +332,18 @@ namespace ArgsTests
             var basicUsage = ArgUsage.GetUsage<PositionedArgs>( "basic");
             Console.WriteLine(basicUsage);
         }
+
+        [TestMethod]
+        public void TestBasicUsageWithNoExeNameThrowsArgException()
+        {
+            try 
+            {
+                var basicUsage = ArgUsage.GetUsage<BasicArgs>();
+            }
+            catch (ArgException ex)
+            {
+                Assert.IsTrue(ex.Message.ToLower().Contains("could not determine the name of your executable automatically"));
+            }
+        }
     }
 }

--- a/PowerArgs/ArgUsage.cs
+++ b/PowerArgs/ArgUsage.cs
@@ -11,8 +11,17 @@ namespace PowerArgs
     {
         public static string GetUsage<T>(string exeName = null)
         {
-            string ret = "Usage: ";
-            ret += exeName ?? Path.GetFileNameWithoutExtension(Assembly.GetEntryAssembly().Location);
+            if (exeName == null)
+            {
+                var assembly = Assembly.GetEntryAssembly();
+                if (assembly == null)
+                {
+                    throw new ArgException("PowerArgs could not determine the name of your executable automatically.  This may happen if you run GetUsage<T>() from within unit tests.  Use GetUsageT>(string exeName) in unit tests to avoid this exception.");
+                }
+                exeName = Path.GetFileNameWithoutExtension(Assembly.GetEntryAssembly().Location);
+            }
+
+            string ret = "Usage: " + exeName;
 
             var actionProperty = ArgAction.GetActionProperty<T>();
 


### PR DESCRIPTION
GetUsage now throws ArgException when it can't figure out the name of
the exe.

I implemented your proposed solution and provided a matching test.  Thanks for allowing me the opportunity to contribute.
