### PR TITLE
Made a ton of changes:

### DIFF
--- a/ArgsTests/BasicTests.cs
+++ b/ArgsTests/BasicTests.cs
@@ -429,7 +429,7 @@ namespace ArgsTests
         {
             var basicUsage = ArgUsage.GetUsage<BasicArgs>("basic");
             ArgUsage.GetUsage<PointArgs>("basic");
-            ArgUsage.GetStyledUsage<PointArgs>("basic").Write();
+            ArgUsage.GetStyledUsage<PointArgs>(exeName: "basic").Write();
             Console.WriteLine(basicUsage);
         }
 
@@ -437,7 +437,7 @@ namespace ArgsTests
         public void TestBasicUsageWithPositioning()
         {
             var basicUsage = ArgUsage.GetUsage<PositionedArgs>( "basic");
-            ArgUsage.GetStyledUsage<PositionedArgs>("basic").Write();
+            ArgUsage.GetStyledUsage<PositionedArgs>(exeName: "basic").Write();
             Console.WriteLine(basicUsage);
         }
 

--- a/PowerArgs/ArgRevivers.cs
+++ b/PowerArgs/ArgRevivers.cs
@@ -34,7 +34,8 @@ namespace PowerArgs
                 (t.GetInterfaces().Contains(typeof(IList)) && t.IsGenericType && CanRevive(t.GetGenericArguments()[0]) ) ||
                 (t.IsArray && CanRevive(t.GetElementType()) ))
                 return true;
-            SearchAssemblyForRevivers(t.Assembly);
+            //SearchAssemblyForRevivers(t.Assembly);
+            SearchAssemblyForRevivers(Assembly.GetEntryAssembly());
             return Revivers.ContainsKey(t);
         }
 

--- a/PowerArgs/ArgValidatorAttributes.cs
+++ b/PowerArgs/ArgValidatorAttributes.cs
@@ -54,6 +54,18 @@ namespace PowerArgs
     }
 
     /// <summary>
+    /// A validator that validates an entire args object.
+    /// </summary>
+    public interface IArgClassValidator
+    {
+        /// <summary>
+        /// A validation method that should throw an exception if any instance member is not valid.
+        /// This validation check occurs after the standard validation mechanism
+        /// </summary>
+        void Validate();
+    }
+
+    /// <summary>
     /// Validates that if the user specifies a value for a property that the value represents a file that exists
     /// as determined by System.IO.File.Exists(file).
     /// </summary>

--- a/PowerArgs/Exceptions.cs
+++ b/PowerArgs/Exceptions.cs
@@ -10,18 +10,35 @@ namespace PowerArgs
     /// </summary>
     public class ArgException : Exception
     {
+
+        internal static string LastAction { get; set; }
+
+        /// <summary>
+        /// If the processing of the arguments has proceed past the stage of determining what action 
+        /// (if any) was issued, this field will hold the action that was parsed.
+        /// </summary>
+        public string Action { get; protected set; }
+
         /// <summary>
         /// Creates a new ArgException given a user friendly message
         /// </summary>
         /// <param name="msg">A user friendly message.</param>
-        public ArgException(string msg) : base(msg) { }
+        public ArgException(string msg)
+            : base(msg)
+        {
+            this.Action = LastAction == null ? null : string.Copy(LastAction);
+        }
 
         /// <summary>
         /// Creates a new ArgException given a user friendly message
         /// </summary>
         /// <param name="msg">A user friendly message.</param>
         /// <param name="inner">The inner exception that caused the problem</param>
-        public ArgException(string msg, Exception inner) : base(msg, inner) { }
+        public ArgException(string msg, Exception inner)
+            : base(msg, inner)
+        {
+            this.Action = LastAction == null ? null : string.Copy(LastAction);
+        }
     }
 
     /// <summary>

--- a/PowerArgs/Extensions.cs
+++ b/PowerArgs/Extensions.cs
@@ -263,6 +263,41 @@ namespace PowerArgs
             }
         }
 
+        internal static T InheritedAttr<T>(this MemberInfo info) where T : class 
+        {
+            var attributes = info.GetCustomAttributes(true);
+            return InheritedAttributes<T>(attributes);
+        }
+
+        internal static T InheritedAttr<T>(this Type info) where T : class 
+        {
+            var attributes = info.GetCustomAttributes(true);
+            return InheritedAttributes<T>(attributes);
+        }
+
+        private static T InheritedAttributes<T>(IEnumerable<object> attributes) where T : class 
+        {
+            T result = default(T);
+
+            bool defined = false;
+            foreach (var attribute in attributes)
+            {
+                if ((attribute as T) != null)
+                {
+                    if (defined)
+                    {
+                        throw new Exception("Too many attributes of same type.");
+                    }
+                    else
+                    {
+                        result = (T)attribute;
+                        defined = true;
+                    }
+                }
+            }
+
+            return result;
+        }
 
         internal static List<T> Attrs<T>(this MemberInfo info)
         {

--- a/PowerArgs/PowerArgs.csproj
+++ b/PowerArgs/PowerArgs.csproj
@@ -88,6 +88,9 @@
     </EmbeddedResource>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PostBuildEvent>copy "$(TargetDir)*" "D:\Work\Sensors2\AudioAnalysis\PowerArgs_Temporary\Debug\*"</PostBuildEvent>
+  </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">


### PR DESCRIPTION
```
- Included the ability to statically invoke action methods
- Added custom attribute stubs for getting descriptions and detailed descriptions
- Added the concept of a custom detailed description
- modded shortcut registration so shortcuts across actions will render consistently for the same named arguments
- Added an argallownull attribute that allows an action to be executed IFF no subsequent arguments follow (skips validation)
- Changed the assembly that searching for custom revivers works on
- Multiple changes to arguage, added public API for returning AST. Also added options for compact formatting
- Added support for class level validation
- Added some helper extensions for finsding inherrited attributes
- Added support for the 'LastAction' static property in the ArgException base class. This allows external API users to at least retieve the action used (is parsed) when an exception is raised.
```
