### PR TITLE
Exceptions being swallowed

### DIFF
--- a/ArgsTests/ActionTests.cs
+++ b/ArgsTests/ActionTests.cs
@@ -110,6 +110,15 @@ namespace ArgsTests
             public string B { get; set; }
         }
 
+        public class FailingProgram
+        {
+            [ArgActionMethod]
+            public static void SomeAction()
+            {
+                throw new Exception();
+            }
+        }
+
         [TestMethod]
         public void TestBasicActionBinding()
         {
@@ -244,6 +253,20 @@ namespace ArgsTests
             {
                 Assert.IsInstanceOfType(ex, typeof(MissingArgException));
                 Assert.AreEqual("No action was specified", ex.Message);
+            }
+        }
+
+        [TestMethod]
+        public void ActionExceptionPreservesOriginalStackTrace()
+        {
+            try
+            {
+                var args = new string[] { "SomeAction" };
+                Args.InvokeAction<FailingProgram>(args);
+            }
+            catch (Exception ex)
+            {
+                Assert.IsTrue(ex.StackTrace.Contains("SomeAction"), "Stack trace did not contain original stack trace");
             }
         }
     }

--- a/PowerArgs/HelperTypesPublic/ArgAction.cs
+++ b/PowerArgs/HelperTypesPublic/ArgAction.cs
@@ -1,6 +1,7 @@
 ﻿using System.Reflection;
 using System;
 using System.Linq;
+using System.Runtime.ExceptionServices;
 
 namespace PowerArgs
 {
@@ -122,7 +123,7 @@ namespace PowerArgs
                 else if(ex.InnerException != null)
                 {
                     PowerLogger.LogLine("Inner exception stack trace: "+ex.InnerException.ToString());
-                    throw ex.InnerException;
+                    ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
                 }
                 else
                 {


### PR DESCRIPTION
I came across the same issue as #65 when calling Args.InvokeAction and dev branch seems to upgraded to targetting 4.5 already so can use the ExceptionDispatchInfo class to fix this issue.