### PR TITLE
Add support for enums with underlying types other than int.

### DIFF
--- a/ArgsTests/BasicTests.cs
+++ b/ArgsTests/BasicTests.cs
@@ -32,6 +32,24 @@ namespace ArgsTests
             Sixteen = 16,
         }
 
+        public enum ByteSizedEnum : byte
+        {
+            Option1,
+            Option2
+        }
+
+        public enum ShortSizedEnum : short
+        {
+            Option1,
+            Option2
+        }
+
+        public enum LongSizedEnum : long
+        {
+            Option1,
+            Option2
+        }
+
         [UsageAutomation]
         public class EnumArgs
         {
@@ -73,6 +91,27 @@ namespace ArgsTests
             {
                 return new MailAddress(value);
             }
+        }
+
+        public class ByteSizedEnumArgs
+        {
+            [DefaultValue(ByteSizedEnum.Option2)]
+            [ArgIgnoreCase]
+            public ByteSizedEnum Option { get; set; }
+        }
+
+        public class ShortSizedEnumArgs
+        {
+            [DefaultValue(ShortSizedEnum.Option2)]
+            [ArgIgnoreCase]
+            public ShortSizedEnum Option { get; set; }
+        }
+
+        public class LongSizedEnumArgs
+        {
+            [DefaultValue(LongSizedEnum.Option2)]
+            [ArgIgnoreCase]
+            public LongSizedEnum Option { get; set; }
         }
 
         public class Point
@@ -435,6 +474,21 @@ namespace ArgsTests
 
             parsed = Args.Parse<EnumArgs>(new string[] { }); // Test the default value
             Assert.AreEqual(BasicEnum.Option2, parsed.Option);
+        }
+
+        [TestMethod]
+        public void TestEnumNonDefaultSize()
+        {
+            var args = new string[] { "-option", "Option1" };
+
+            var parsedByteSize = Args.Parse<ByteSizedEnumArgs>(args);
+            Assert.AreEqual(ByteSizedEnum.Option1, parsedByteSize.Option);
+
+            var parsedShortSize = Args.Parse<ShortSizedEnumArgs>(args);
+            Assert.AreEqual(ShortSizedEnum.Option1, parsedShortSize.Option);
+
+            var parsedLongSize = Args.Parse<LongSizedEnumArgs>(args);
+            Assert.AreEqual(LongSizedEnum.Option1, parsedLongSize.Option);
         }
 
         [TestMethod]

--- a/PowerArgs/HelperTypesInternal/ArgRevivers.cs
+++ b/PowerArgs/HelperTypesInternal/ArgRevivers.cs
@@ -50,7 +50,7 @@ namespace PowerArgs
         {
             if (value.Contains(","))
             {
-                int ret = 0;
+                long ret = 0;
                 var values = value.Split(',').Select(v => v.Trim());
                 foreach (var enumValue in values)
                 {
@@ -82,22 +82,25 @@ namespace PowerArgs
             }
         }
 
-        private static int ParseEnumValue(Type t, string valueString, bool ignoreCase)
+        private static long ParseEnumValue(Type t, string valueString, bool ignoreCase)
         {
-            int rawInt;
+            long rawValue;
+            object enumMatch = null;
 
-            if (int.TryParse(valueString, out rawInt))
+            if (long.TryParse(valueString, out rawValue))
             {
-                return (int)Enum.ToObject(t, rawInt);
+                enumMatch = Enum.ToObject(t, rawValue);
+            }
+            else
+            {
+                if (!t.TryMatchEnumShortcut(valueString, ignoreCase, out enumMatch))
+                {
+                    enumMatch = Enum.Parse(t, valueString, ignoreCase);
+                }
             }
 
-            object enumShortcutMatch;
-            if (t.TryMatchEnumShortcut(valueString, ignoreCase, out enumShortcutMatch))
-            {
-                return (int)enumShortcutMatch;
-            }
-
-            return (int)Enum.Parse(t, valueString, ignoreCase);
+            Debug.Assert(enumMatch != null);
+            return (long)Convert.ChangeType(enumMatch, typeof(long));
         }
 
         /// <summary>


### PR DESCRIPTION
The ArgsReviver doesn't handle enums when the underlying type is
something other than int. This change adds support for enums with
underlying types byte, short, int and long.

Added a new test for the various enum sizes.
