### PR TITLE
Fixes incorrect invocation of previous action when an incorrect action is specified in a REPL session.

### DIFF
--- a/ArgsTests/TabCompletionTests.cs
+++ b/ArgsTests/TabCompletionTests.cs
@@ -425,6 +425,31 @@ namespace ArgsTests
             }
         }
 
+        [TestMethod]
+        public void TestInvalidActionDoesNotCallPreviousActionWithREPL()
+        {
+            try
+            {
+                TestConsoleProvider.SimulateConsoleInput("Do{enter}invalidaction{enter}quit");
+                var parsed = Args.InvokeAction<ArgsREPLWithAction>("$");
+                Assert.Fail("An exception should have been thrown");
+            }
+            catch (UnknownActionArgException ex)
+            {
+                Assert.IsTrue(ex.Message.Contains("invalidaction"));
+                Console.WriteLine("Yay!");
+            }
+        }
+
+        [TabCompletion(REPL = true, Indicator = "$")]
+        public class ArgsREPLWithAction
+        {
+            [ArgActionMethod]
+            public void Do()
+            {
+            }
+        }
+
         public class ArgsWithRequiredAndNoREPL
         {
             [ArgRequired(PromptIfMissing = true)]

--- a/PowerArgs/Hooks/TabCompletion.cs
+++ b/PowerArgs/Hooks/TabCompletion.cs
@@ -238,6 +238,7 @@ namespace PowerArgs
             }
 
             context.CmdLineArgs = newCommandLineArray;
+            context.SpecifiedAction = null;
             AddToHistory(newCommandLineString);
         }
 


### PR DESCRIPTION
Test case to reproduce issue #85.

My current fix for the problem is adding`context.SpecifiedAction = null;` to the end of the `TabCompletion.BeforeParse` method.

However, I am not sure if this is the correct location to fix the problem and if this has any side effects.