### PR TITLE
support revivers in executing assembly

### DIFF
--- a/PowerArgs/HelperTypesInternal/ArgRevivers.cs
+++ b/PowerArgs/HelperTypesInternal/ArgRevivers.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -39,7 +39,14 @@ namespace PowerArgs
                 (t.GetInterfaces().Contains(typeof(IList)) && t.IsGenericType && CanRevive(t.GetGenericArguments()[0])) ||
                 (t.IsArray && CanRevive(t.GetElementType())))
                 return true;
+            
             SearchAssemblyForRevivers(t.Assembly);
+
+            var entryAssembly = Assembly.GetEntryAssembly();
+            if (t.Assembly.FullName != entryAssembly.FullName)
+            {
+                SearchAssemblyForRevivers(entryAssembly);
+            }
 
             if (System.ComponentModel.TypeDescriptor.GetConverter(t).CanConvertFrom(typeof(string))) return true;
 


### PR DESCRIPTION
If the reviver is not in the same assembly as the custom type we cannot
find the reviver, its not always possible to update the assembly with
the custom type, therefore also search the executing assembly.
