### PR TITLE
Change 'lt' to 'gt' in command line arguments definition (in usage summary)

### DIFF
--- a/PowerArgs/ArgDefinition/CommandLineArgumentsDefinition.cs
+++ b/PowerArgs/ArgDefinition/CommandLineArgumentsDefinition.cs
@@ -223,7 +223,7 @@ namespace PowerArgs
             {
                 if (positionArg.IsRequired)
                 {
-                    ret += lt + positionArg.DefaultAlias + lt+" ";
+                    ret += lt + positionArg.DefaultAlias + gt +" ";
                 }
                 else
                 {


### PR DESCRIPTION
Currently the usage summary looks a bit weird:

```
The argument 'SubCommand' is required
Usage - Tool test <SubCommand< -options

GlobalOption       Description
Help (-?, -h)      Shows this help.
SubCommand* (-S)   Sub command to run.
```
