### PR TITLE
Fix InvalidArgDefinitionException message in case of invalid metadata.

### DIFF
--- a/PowerArgs/Extensions/IEnumerableOfIArgMetadata.cs
+++ b/PowerArgs/Extensions/IEnumerableOfIArgMetadata.cs
@@ -16,7 +16,7 @@ namespace PowerArgs
 
             foreach (var invalidMetadata in invalid)
             {
-                throw new InvalidArgDefinitionException("Metadata of type '" + invalidMetadata.GetType().Name + "' does not implement " + typeof(ICommandLineArgumentsDefinitionMetadata).Name);
+                throw new InvalidArgDefinitionException("Metadata of type '" + invalidMetadata.GetType().Name + "' does not implement " + typeof(T).Name);
             }
 
             return valid.ToList();


### PR DESCRIPTION
The message was potentially misleading always requesting
ICommandLineArgumentsDefinitionMetadata types in the reported error.