### PR TITLE
Make [OmitFromUsageDocs] work for methods as well as arguments.

### DIFF
--- a/ArgsTests/Resources/PhotoAlbumManagerExpectedBrowserUsage.txt
+++ b/ArgsTests/Resources/PhotoAlbumManagerExpectedBrowserUsage.txt
@@ -53,23 +53,23 @@
                             <td>OPTION</td>
                             <td>DESCRIPTION</td>
                         </tr>
-                                                                        <tr>
+                                                <tr>
                             <td class='option-col program-specific-content'>StorageAccountName</td>
                             <td class='desc-col program-specific-content'>-The storage account to connect to</td>
                         </tr>
-                                                                                                                        <tr>
+                                                                        <tr>
                             <td class='option-col program-specific-content'>StorageAccountKey</td>
                             <td class='desc-col program-specific-content'>-The storage key to use to connect</td>
                         </tr>
-                                                                                                                        <tr>
+                                                                        <tr>
                             <td class='option-col program-specific-content'>Container</td>
                             <td class='desc-col program-specific-content'>-The storage container to target<span class='defaultvalue'> Default<span /><span class='defaultvalue'>=<span /><span class='defaultvalue'>DefaultAlbum<span /></td>
                         </tr>
-                                                                                                                        <tr>
+                                                                        <tr>
                             <td class='option-col program-specific-content'>UseHttps</td>
                             <td class='desc-col program-specific-content'>-Set this flag to use https</td>
                         </tr>
-                                                                                            </table>
+                                                                    </table>
                                     </div>
             </div>
         </li>
@@ -88,15 +88,15 @@
                             <td>OPTION</td>
                             <td>DESCRIPTION</td>
                         </tr>
-                                                                        <tr>
+                                                <tr>
                             <td class='option-col program-specific-content'>BlobFilePath</td>
                             <td class='desc-col program-specific-content'>-The name of a blob to download</td>
                         </tr>
-                                                                                                                        <tr>
+                                                                        <tr>
                             <td class='option-col program-specific-content'>LocalFile</td>
                             <td class='desc-col program-specific-content'>-The local path to download to.  This description does not really need to be this long, but I need to test to make sure that the new description formatting feature that cleanly wraps long descriptions is working properly.  This long description should be enough to test that out!</td>
                         </tr>
-                                                                                                                        <tr>
+                                                                        <tr>
                             <td class='option-col program-specific-content'>ConflictPolicy</td>
                             <td class='desc-col program-specific-content'>-What do do if there is a conflict when downloading a file<span class='defaultvalue'> Default<span /><span class='defaultvalue'>=<span /><span class='defaultvalue'>Throw<span /></td>
                         </tr>
@@ -112,23 +112,23 @@
                             <td class='option-col program-specific-content'></td>
                             <td class='defaultValue'> ClientWins</td>
                         </tr>
-                                                                                                                                                <tr>
+                                                                                                <tr>
                             <td class='option-col program-specific-content'>StorageAccountName</td>
                             <td class='desc-col program-specific-content'>-The storage account to connect to</td>
                         </tr>
-                                                                                                                        <tr>
+                                                                        <tr>
                             <td class='option-col program-specific-content'>StorageAccountKey</td>
                             <td class='desc-col program-specific-content'>-The storage key to use to connect</td>
                         </tr>
-                                                                                                                        <tr>
+                                                                        <tr>
                             <td class='option-col program-specific-content'>Container</td>
                             <td class='desc-col program-specific-content'>-The storage container to target<span class='defaultvalue'> Default<span /><span class='defaultvalue'>=<span /><span class='defaultvalue'>DefaultAlbum<span /></td>
                         </tr>
-                                                                                                                        <tr>
+                                                                        <tr>
                             <td class='option-col program-specific-content'>UseHttps</td>
                             <td class='desc-col program-specific-content'>-Set this flag to use https</td>
                         </tr>
-                                                                                            </table>
+                                                                    </table>
                                         <h4>Examples</h4>
                                         <h3></h3>
                     <p>Downloads a blob called ceremony.png to a temp folder on the local machine</p>
@@ -151,15 +151,15 @@
                             <td>OPTION</td>
                             <td>DESCRIPTION</td>
                         </tr>
-                                                                        <tr>
+                                                <tr>
                             <td class='option-col program-specific-content'>LocalFile</td>
                             <td class='desc-col program-specific-content'>-If specified the single file will be uploaded</td>
                         </tr>
-                                                                                                                        <tr>
+                                                                        <tr>
                             <td class='option-col program-specific-content'>LocalDirectory</td>
                             <td class='desc-col program-specific-content'>-If specified, all files in the directory will be uploaded</td>
                         </tr>
-                                                                                                                        <tr>
+                                                                        <tr>
                             <td class='option-col program-specific-content'>ConflictPolicy</td>
                             <td class='desc-col program-specific-content'>-What do do if there is a conflict when uploading a file<span class='defaultvalue'> Default<span /><span class='defaultvalue'>=<span /><span class='defaultvalue'>Throw<span /></td>
                         </tr>
@@ -175,23 +175,23 @@
                             <td class='option-col program-specific-content'></td>
                             <td class='defaultValue'> ClientWins</td>
                         </tr>
-                                                                                                                                                <tr>
+                                                                                                <tr>
                             <td class='option-col program-specific-content'>StorageAccountName</td>
                             <td class='desc-col program-specific-content'>-The storage account to connect to</td>
                         </tr>
-                                                                                                                        <tr>
+                                                                        <tr>
                             <td class='option-col program-specific-content'>StorageAccountKey</td>
                             <td class='desc-col program-specific-content'>-The storage key to use to connect</td>
                         </tr>
-                                                                                                                        <tr>
+                                                                        <tr>
                             <td class='option-col program-specific-content'>Container</td>
                             <td class='desc-col program-specific-content'>-The storage container to target<span class='defaultvalue'> Default<span /><span class='defaultvalue'>=<span /><span class='defaultvalue'>DefaultAlbum<span /></td>
                         </tr>
-                                                                                                                        <tr>
+                                                                        <tr>
                             <td class='option-col program-specific-content'>UseHttps</td>
                             <td class='desc-col program-specific-content'>-Set this flag to use https</td>
                         </tr>
-                                                                                            </table>
+                                                                    </table>
                                         <h4>Examples</h4>
                                         <h3></h3>
                     <p>Uploads all the files in the local directory to the 'wedding' container</p>

--- a/ArgsTests/UsageTests.cs
+++ b/ArgsTests/UsageTests.cs
@@ -19,6 +19,11 @@ namespace ArgsTests
         public string StringArgs { get; set; }
         [ArgDescription("An int arg")]
         public int IntArgs { get; set; }
+        [ArgActionMethod, OmitFromUsageDocs, ArgDescription("Displays the help")]
+        public void Help()
+        {
+            ArgUsage.GenerateUsageFromTemplate(typeof(BasicUsageArgs)).WriteLine();
+        }
 
         [OmitFromUsageDocs, ArgDescription("WE SHOULD NEVER SEE THIS")]
         public string SecretArg { get; set; }
@@ -123,6 +128,7 @@ namespace ArgsTests
             var usage = ArgUsage.GenerateUsageFromTemplate(typeof(BasicUsageArgs));
             Assert.IsFalse(usage.Contains("SecretArg"));
             Assert.IsFalse(usage.Contains("WE SHOULD NEVER"));
+            Assert.IsFalse(usage.Contains("help"));
         }
 
         #region Samples

--- a/PowerArgs/ArgDefinition/CommandLineAction.cs
+++ b/PowerArgs/ArgDefinition/CommandLineAction.cs
@@ -75,13 +75,8 @@ namespace PowerArgs
 
             ret += DefaultAlias + " ";
 
-            foreach (var positionArg in (from a in Arguments where a.Position >= 1 select a).OrderBy(a => a.Position))
+            foreach (var positionArg in (from a in UsageArguments where a.Position >= 1 select a).OrderBy(a => a.Position))
             {
-                if(positionArg.OmitFromUsage)
-                {
-                    continue;
-                }
-
                 if (positionArg.IsRequired)
                 {
                     ret += lt + positionArg.DefaultAlias + gt+" ";
@@ -92,7 +87,7 @@ namespace PowerArgs
                 }
             }
 
-            if (Arguments.Where(a => a.Position < 0).Count() > 0)
+            if (UsageArguments.Any(a => a.Position < 0))
             {
                 ret += "-options";
             }
@@ -138,6 +133,15 @@ namespace PowerArgs
             {
                 overrides.Set("IgnoreCase", value);
             }
+        }
+
+        /// <summary>
+        /// Specifies whether this action should be omitted from usage documentation
+        /// </summary>
+        public bool OmitFromUsage
+        {
+            get => overrides.Get<OmitFromUsageDocs, bool>("OmitFromUsage", Metadata, p => true, false);
+            set => overrides.Set("OmitFromUsage", value);
         }
 
         /// <summary>

--- a/PowerArgs/ArgDefinition/CommandLineArgumentsDefinition.cs
+++ b/PowerArgs/ArgDefinition/CommandLineArgumentsDefinition.cs
@@ -186,6 +186,11 @@ namespace PowerArgs
         }
 
         /// <summary>
+        /// Returns true if there is at least one action that should be visible in the usage, false otherwise.
+        /// </summary>
+        public bool HasUsageActions => UsageActions.Any();
+
+        /// <summary>
         /// Creates a usage summary string that takes into account actions, positional argument, etc.
         /// </summary>
         public string UsageSummary
@@ -311,6 +316,9 @@ namespace PowerArgs
         /// Actions that are defined for this definition.  If you have at least one action then the end user must specify the action as the first argument to your program.
         /// </summary>
         public List<CommandLineAction> Actions { get; private set; }
+
+        public List<CommandLineAction>  UsageActions =>
+            (from action in Actions where !action.OmitFromUsage select action).ToList();
 
         /// <summary>
         /// Arbitrary metadata that has been added to the definition

--- a/PowerArgs/Metadata/OmitFromUsageDocs.cs
+++ b/PowerArgs/Metadata/OmitFromUsageDocs.cs
@@ -7,7 +7,7 @@ namespace PowerArgs
     /// in the output created by the ArgUsage class (the class that auto generates usage documentation).
     /// </summary>
     [AttributeUsage(AttributeTargets.Property | AttributeTargets.Method | AttributeTargets.Parameter)]
-    public class OmitFromUsageDocs : Attribute,  ICommandLineActionMetadata
+    public class OmitFromUsageDocs : Attribute, IArgumentOrActionMetadata
     {
 
     }

--- a/PowerArgs/Metadata/OmitFromUsageDocs.cs
+++ b/PowerArgs/Metadata/OmitFromUsageDocs.cs
@@ -7,7 +7,7 @@ namespace PowerArgs
     /// in the output created by the ArgUsage class (the class that auto generates usage documentation).
     /// </summary>
     [AttributeUsage(AttributeTargets.Property | AttributeTargets.Method | AttributeTargets.Parameter)]
-    public class OmitFromUsageDocs : Attribute,  ICommandLineArgumentMetadata
+    public class OmitFromUsageDocs : Attribute,  ICommandLineActionMetadata
     {
 
     }

--- a/PowerArgs/Resources/UsageTemplates.cs
+++ b/PowerArgs/Resources/UsageTemplates.cs
@@ -31,8 +31,9 @@ Usage - {{ExeName Cyan!}} {{SpecifiedAction.UsageSummary Cyan!}}
 !{{if}}
 {{ifnot HasSpecifiedAction}}
 
+{{if HasUsageActions}}
 Actions
-{{each action in Actions}}
+{{each action in UsageActions}}
 
   {{action.UsageSummary Cyan!}} - {{action.Description!}}
 
@@ -48,6 +49,7 @@ Actions
 
 !{{if}}
 !{{each}}
+!{{if}}
 !{{ifnot}}
 !{{if}}
 {{if HasExamples }}
@@ -105,7 +107,7 @@ Examples{{each example in Examples}}
     {{if HasActions}}
     <h2>Actions</h2>
     <ul>
-        {{each action in Actions}}
+        {{each action in UsageActions}}
         <li>
             <div>
                 <span class='program-specific-content'>{{action.DefaultAlias!}}</span>
@@ -121,8 +123,7 @@ Examples{{each example in Examples}}
                             <td>OPTION</td>
                             <td>DESCRIPTION</td>
                         </tr>
-                        {{each actionArgument in action.Arguments}}
-                        {{if actionArgument.IncludeInUsage}}
+                        {{each actionArgument in action.UsageArguments}}
                         <tr>
                             <td class='option-col program-specific-content'>{{actionArgument.DefaultAlias!}}</td>
                             <td class='desc-col program-specific-content'>-{{actionArgument.Description!}}{{if actionArgument.HasDefaultValue}}<span class='defaultvalue'> Default<span /><span class='defaultvalue'>=<span /><span class='defaultvalue'>{{actionArgument.DefaultValue!}}<span />!{{if}}</td>
@@ -134,7 +135,6 @@ Examples{{each example in Examples}}
                             <td class='defaultValue'> {{enumVal!}}</td>
                         </tr>
                         !{{each}}
-                        !{{if}}
                         !{{if}}
                         !{{each}}
                     </table>

--- a/PowerArgs/Templating/TableExpression.cs
+++ b/PowerArgs/Templating/TableExpression.cs
@@ -109,7 +109,7 @@ namespace PowerArgs
 
             foreach(var element in collection)
             {
-                if(element is CommandLineArgument && ((CommandLineArgument)element).OmitFromUsage)
+                if((element is CommandLineArgument argument && argument.OmitFromUsage) || (element is CommandLineAction action && action.OmitFromUsage))
                 {
                     continue;
                 }


### PR DESCRIPTION
Hi,
Hopefully I haven't totally misunderstood the way things are supposed to work :wink: 
This should make the HelloWorld project run successfully _and _ the usage message to not display the description of the Help command.
Please find below more information about the changes, let me know if anything is unclear.
Kind regards.
Amine

* PhotoAlbumManagerExpectedBrowserUsage.txt: Update expected text as empty
spaces differences are not significant for HTML rendering and doesn't seem
obviously related to my changes. It's yet unclear to me if these diffs need to
be investigated.

* UsageTests.cs: Add the case of a method that should be Omitted from usage doc.

* CommandLineAction.cs (UsageSummaryHTMLEncoded): loop in the UsageArguments and
therefore drop the test from within the loop.
(OmitFromUsage): New method indicating if the command should be omitted from
usage.

* CommandLineArgumentsDefinitions.cs (UsageActions): Returns only the actions
that should be present in the usage.
  (HasUsageActions): Indicate if at least one action is present in the usage.

* OmitFromUsageDocs: make it implement the IArgumentOrActionMetadata do make
the annotation usable for actions as well.

* UsageTemplates.cs: Make use of the news methods to only print actions if at
least one action is present.

* TableExpression.cs: filtrate the CommandLineArgument and CommentLineAction
instances that should be omitted from the evaluated elements.