### PR TITLE
Fix endless loop when trying to wrap long words

### DIFF
--- a/ArgsTests/ConsoleTableBuilderTests.cs
+++ b/ArgsTests/ConsoleTableBuilderTests.cs
@@ -133,5 +133,26 @@ Alic...      Two Microsoft     The wife of the author of PowerArgs, the world's 
             Assert.IsTrue(table.Contains("John"));
             Assert.IsTrue(table.Contains("Doe"));
         }
+
+        [TestMethod]
+        public void ConsoleTableTestLongWord()
+        {
+            ConsoleProvider.Current.BufferWidth = 160;
+            ConsoleTableBuilder builder = new ConsoleTableBuilder();
+
+            var columns = new List<ConsoleString>() { new ConsoleString("Word 1"), new ConsoleString("Word 2") };
+            var rows = new List<List<ConsoleString>>()
+            {
+                new List<ConsoleString>(){new ConsoleString(" ThisIsAVeryLongWord"), new ConsoleString("Hello. ThisIsAVeryLongWord ThisIsAnother AnotherVeryLongWord")}
+            };
+
+            var columnOverflowBehaviors = new List<ColumnOverflowBehavior>()
+            {
+                new SmartWrapOverflowBehavior(){DefineMaxWidthBasedOnConsoleWidth = false, MaxWidthBeforeWrapping = 10},
+                new SmartWrapOverflowBehavior(){DefineMaxWidthBasedOnConsoleWidth = false, MaxWidthBeforeWrapping = 10}
+            };
+
+            builder.FormatAsTable(columns, rows, rowPrefix: "", columnOverflowBehaviors: columnOverflowBehaviors);
+        }
     }
 }

--- a/PowerArgs/HelperTypesPublic/ConsoleTableBuilder.cs
+++ b/PowerArgs/HelperTypesPublic/ConsoleTableBuilder.cs
@@ -319,7 +319,14 @@ namespace PowerArgs
                 {
                     if (char.IsWhiteSpace(segment[i].Value))
                     {
-                        segment = value.Substring(0, i);
+                        if (i != 0)
+                        {
+                            segment = value.Substring(0, i);
+                        }
+                        else
+                        {
+                            segment = value.Substring(0, smartWrap.MaxWidthBeforeWrapping + 1);
+                        }
                         break;
                     }
                     lookBehindLimit--;


### PR DESCRIPTION
Hi,

if you call FormatAsTable with a row containing a string that contains a consecutive substring of non-space characters, which is longer than the chosen MaxWidthBeforeWrapping attribute of the SmartWrapOverflowBehavior and is preceded by a space, the FormatAsWrappedSegments method of the ConsoleTableBuilder will go into an endless loop until it has eaten up all the memory. 

This pull request introduces a unit test for that and fixes the issue by checking if we are at the beginning of a segment before cutting off a substring.