### PR TITLE
Add ArgDisplayName attribute.

### DIFF
--- a/PowerArgs/ArgDefinition/CommandLineArgument.cs
+++ b/PowerArgs/ArgDefinition/CommandLineArgument.cs
@@ -79,7 +79,7 @@ namespace PowerArgs
                 for (aliasIndex = 0; aliasIndex < aliases.Count; aliasIndex++)
                 {
                     if (aliases[aliasIndex] == DefaultAlias) continue;
-                    var proposedInlineAliases = inlineAliasInfo == string.Empty ? "-"+aliases[aliasIndex] : inlineAliasInfo + ", -" + aliases[aliasIndex];
+                    var proposedInlineAliases = inlineAliasInfo == string.Empty ? "-" + aliases[aliasIndex] : inlineAliasInfo + ", -" + aliases[aliasIndex];
                     inlineAliasInfo = proposedInlineAliases;
                 }
 
@@ -87,7 +87,7 @@ namespace PowerArgs
             }
         }
 
-     
+
         internal string Syntax
         {
             get
@@ -99,9 +99,9 @@ namespace PowerArgs
                     ret += "*";
                 }
 
-                if(PrimaryShortcutAlias.Length > 0)
+                if (PrimaryShortcutAlias.Length > 0)
                 {
-                    ret += " ("+PrimaryShortcutAlias+")";
+                    ret += " (" + PrimaryShortcutAlias + ")";
                 }
 
                 return ret;
@@ -162,7 +162,7 @@ namespace PowerArgs
                     return true;
                 }
 
-                if(ArgumentType.IsGenericType == false)
+                if (ArgumentType.IsGenericType == false)
                 {
                     return false;
                 }
@@ -173,8 +173,8 @@ namespace PowerArgs
                 }
 
                 var nullableType = ArgumentType.GetGenericArguments().FirstOrDefault();
-                
-                if(nullableType == null)
+
+                if (nullableType == null)
                 {
                     return false;
                 }
@@ -188,7 +188,7 @@ namespace PowerArgs
         /// </summary>
         public bool OmitFromUsage
         {
-            get => overrides.Get<OmitFromUsageDocs, bool>("OmitFromUsage", Metadata, p =>true, false);
+            get => overrides.Get<OmitFromUsageDocs, bool>("OmitFromUsage", Metadata, p => true, false);
             set => overrides.Set("OmitFromUsage", value);
         }
 
@@ -262,8 +262,8 @@ namespace PowerArgs
                 }
 
                 var enumType = ArgumentType;
-                
-                if(enumType.IsEnum == false)
+
+                if (enumType.IsEnum == false)
                 {
                     // we must be dealing with a nullable<enum> since IsEnum returned true above
                     enumType = enumType.GetGenericArguments()[0];
@@ -316,7 +316,7 @@ namespace PowerArgs
         /// was created manually then this value will be null.
         /// </summary>
         public object Source { get; set; }
-        
+
         /// <summary>
         /// This property will contain the parsed value of the command line argument if parsing completed successfully.
         /// </summary>
@@ -338,6 +338,23 @@ namespace PowerArgs
             }
         }
 
+        /// <summary>
+        /// A customized argument name to display.
+        /// </summary>
+        /*
+        public string DisplayName
+        {
+            get
+            {
+                return overrides.Get<ArgDisplayName, string>("DisplayName", Metadata, d => d.DisplayName, string.Empty);
+            }
+            set
+            {
+                overrides.Set("DisplayName", value);
+            }
+        }
+        */
+
         internal CommandLineArgument()
         {
             MustBeRevivable = true;
@@ -347,7 +364,7 @@ namespace PowerArgs
             ArgumentType = typeof(string);
             Position = -1;
         }
- 
+
         /// <summary>
         /// Creates a command line argument of the given type and sets the first default alias.
         /// </summary>
@@ -438,7 +455,7 @@ namespace PowerArgs
             ret.ArgumentType = parameter.ParameterType;
             ret.Source = parameter;
             ret.DefaultValue = parameter.HasAttr<DefaultValueAttribute>() ? parameter.Attr<DefaultValueAttribute>().Value : null;
-            
+
             ret.IgnoreCase = true;
 
             if (parameter.Member.DeclaringType.HasAttr<ArgIgnoreCase>() && parameter.Member.DeclaringType.Attr<ArgIgnoreCase>().IgnoreCase == false)
@@ -498,7 +515,7 @@ namespace PowerArgs
             {
                 if (v.ImplementsValidateAlways)
                 {
-                    v.ValidateAlways(this, ref commandLineValue);  
+                    v.ValidateAlways(this, ref commandLineValue);
                 }
                 else if (commandLineValue != null)
                 {
@@ -522,7 +539,7 @@ namespace PowerArgs
                         RevivedValue = ArgRevivers.Revive(ArgumentType, Aliases.First(), commandLineValue);
                     }
                 }
-                catch(TargetInvocationException ex)
+                catch (TargetInvocationException ex)
                 {
                     if (ex.InnerException != null && ex.InnerException is ArgException)
                     {
@@ -641,25 +658,46 @@ namespace PowerArgs
 
             bool excludeName = info.Attrs<ArgShortcut>().Where(s => s.Policy == ArgShortcutPolicy.ShortcutsOnly).Any();
 
+            string retAlias = "";
+
             if (excludeName == false)
             {
-                knownShortcuts.Add(info.Name);
+                string knownShortcutsAlias;
 
-                if (CommandLineAction.IsActionImplementation(info) && info.Name.EndsWith(Constants.ActionArgConventionSuffix))
+                if (info.HasAttr<ArgDisplayName>())
                 {
-                    ret.Add(info.Name.Substring(0, info.Name.Length - Constants.ActionArgConventionSuffix.Length));
+                    var displayName = info.Attrs<ArgDisplayName>();
+                    if (displayName.Count > 1)
+                    {
+                        throw new DuplicateArgException("Argument specified more than once: " + displayName[0].DisplayName);
+                    }
+
+                    knownShortcutsAlias = displayName[0].DisplayName;
+                    retAlias = displayName[0].DisplayName;
                 }
                 else
                 {
-                    ret.Add(info.Name);
+                    knownShortcutsAlias = info.Name;
+
+                    if (CommandLineAction.IsActionImplementation(info) && info.Name.EndsWith(Constants.ActionArgConventionSuffix))
+                    {
+                        retAlias = info.Name.Substring(0, info.Name.Length - Constants.ActionArgConventionSuffix.Length);
+                    }
+                    else
+                    {
+                        retAlias = info.Name;
+                    }
                 }
+
+                knownShortcuts.Add(knownShortcutsAlias);
+                ret.Add(retAlias);
             }
 
             var attrs = info.Attrs<ArgShortcut>();
 
             if (attrs.Count == 0)
             {
-                var shortcut = GenerateShortcutAlias(info.Name, knownShortcuts, ignoreCase);
+                var shortcut = GenerateShortcutAlias(retAlias == "" ? info.Name : retAlias, knownShortcuts, ignoreCase);
                 if (shortcut != null)
                 {
                     knownShortcuts.Add(shortcut);

--- a/PowerArgs/Metadata/ArgDisplayName.cs
+++ b/PowerArgs/Metadata/ArgDisplayName.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace PowerArgs
+{
+    /// <summary>
+    /// Use this attribute to customize your property argument's name to display.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Method | AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Class)]
+    public class ArgDisplayName : Attribute, IGlobalArgMetadata
+    {
+        /// <summary>
+        /// A customized argument name to display.
+        /// </summary>
+        public string DisplayName { get; private set; }
+
+        /// <summary>
+        /// Creates a new ArgDisplayName attribute.
+        /// </summary>
+        /// <param name="displayName">A customized argument name to display.</param>
+        public ArgDisplayName(string displayName)
+        {
+            this.DisplayName = displayName;
+        }
+    }
+}

--- a/PowerArgsTestCore/Core/DisplayNameTests.cs
+++ b/PowerArgsTestCore/Core/DisplayNameTests.cs
@@ -1,0 +1,57 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using PowerArgs;
+
+namespace ArgsTests
+{
+    [TestClass]
+    [TestCategory(Categories.Core)]
+    public class DisplayNameTests
+    {
+        public class PropertyDisplayNameTestsArgs
+        {
+            [ArgDisplayName("DisplayName")]
+            public string Property { get; set; }
+        }
+
+        public class MethodDisplayNameTestsArgs
+        {
+            [ArgActionMethod, ArgDescription("Adds the two operands"), ArgDisplayName("Add")]
+            public void MyAddOperation(TwoOperandArgs args)
+            {
+                sum = args.Value1 + args.Value2;
+            }
+
+            public static int sum { get; set; } = 0;
+        }
+
+        public class TwoOperandArgs
+        {
+            [ArgRequired, ArgDescription("The first operand to process"), ArgPosition(1)]
+            public int Value1 { get; set; }
+            [ArgRequired, ArgDescription("The second operand to process"), ArgPosition(2)]
+            public int Value2 { get; set; }
+        }
+
+        [TestMethod]
+        public void TestPropertyDisplayName()
+        {
+            var usage = ArgUsage.GenerateUsageFromTemplate(typeof(PropertyDisplayNameTestsArgs));
+            Assert.IsTrue(usage.Contains("DisplayName"));
+            Assert.IsTrue(usage.Contains("-D"));
+        }
+
+        [TestMethod]
+        public void TestMethodDisplayName()
+        {
+            var usage = ArgUsage.GenerateUsageFromTemplate(typeof(MethodDisplayNameTestsArgs));
+            Assert.IsTrue(usage.Contains("Add"));
+            Assert.IsTrue(!usage.Contains("MyAddOperation"));
+
+            var args = new string[] { "Add", "1", "2" };
+            var initSum = MethodDisplayNameTestsArgs.sum;
+            var parsed = Args.InvokeAction<MethodDisplayNameTestsArgs>(args);
+            Assert.IsTrue(initSum == 0);
+            Assert.AreEqual(3, MethodDisplayNameTestsArgs.sum);
+        }
+    }
+}

--- a/readme.md
+++ b/readme.md
@@ -162,6 +162,7 @@ These attributes can be specified on argument properties. PowerArgs uses this me
 
 * `[ArgPosition(0)]` This argument can be specified by position (no need for -propName)
 * `[ArgShortcut("n")]` Lets the user specify -n
+* `[ArgDisplayName("displayName")]` A customized argument property name or action method name to display. 
 * `[ArgDescription("Description of the argument")]`
 * `[ArgExample("example text", "Example description")]`
 * `[HelpHook]` Put this on a boolean property and when the user specifies that boolean. PowerArgs will display the help info and stop processing any additional work. If the user is in the context of an action (e.g. myprogram myaction -help) then help is shown for the action in context only.


### PR DESCRIPTION
Hi, 
as #143, sometimes we need to set argument name different with property name or method name, so I add the ArgDisplayName attribute to do this. The ArgDisplayName attribute can be set to both property and action method. See the DisplayNameTests.cs for the specific usage format.