### PR TITLE
Slash issue with positional arguments on Unix system

### DIFF
--- a/PowerArgs/HelperTypesInternal/ArgParser.cs
+++ b/PowerArgs/HelperTypesInternal/ArgParser.cs
@@ -33,7 +33,8 @@ namespace PowerArgs
                     result.ImplicitParameters.Add(0, token);
                     argumentPosition++;
                 }
-                else if (token.StartsWith("/"))
+                // don't affect tokens on linux & macOS
+                else if (token.StartsWith("/") && OperatingSystem.IsWindows())  
                 {
                     var param = ParseSlashExplicitOption(token);
                     if (result.ExplicitParameters.ContainsKey(param.Key)) throw new DuplicateArgException("Argument specified more than once: " + param.Key);

--- a/PowerArgs/OperatingSystem.cs
+++ b/PowerArgs/OperatingSystem.cs
@@ -3,7 +3,7 @@ using System.Runtime.InteropServices;
 namespace PowerArgs
 {
     /// <summary>
-    /// 
+    /// helper class to detect which OS we are on
     /// https://mariusschulz.com/blog/detecting-the-operating-system-in-net-core
     /// </summary>
     public static class OperatingSystem

--- a/PowerArgs/OperatingSystem.cs
+++ b/PowerArgs/OperatingSystem.cs
@@ -1,0 +1,18 @@
+using System.Runtime.InteropServices;
+
+namespace PowerArgs
+{
+    /// <summary>
+    /// 
+    /// https://mariusschulz.com/blog/detecting-the-operating-system-in-net-core
+    /// </summary>
+    public static class OperatingSystem
+    {
+        /// <summary>
+        /// Indicates if assembly is running on Windows OS
+        /// </summary>
+        /// <returns>True if running on Windows OS, false otherwise</returns>
+        public static bool IsWindows() =>
+            RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+    }
+}


### PR DESCRIPTION
Add code to ignore using token starting with slash (/)  on non-Windows OS